### PR TITLE
Specifies the node engine in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,15 @@
 		"dev": "vite",
 		"build": "tsc && vite build",
 		"preview": "vite preview",
-		"storybook": "export NODE_OPTIONS=--openssl-legacy-provider; start-storybook -p 6006",
+		"storybook": "start-storybook -p 6006",
 		"build-storybook": "build-storybook"
 	},
 	"dependencies": {
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0"
+	},
+	"engines": {
+		"node": ">=16.0.0 <17.0.0"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.20.12",


### PR DESCRIPTION
Especifica que la versión de Node se encuentre entre el rango de la versión 16.0.0 y 17.0.0 para poder lanzar al browser el Storybook sin problemas de compatibilidad con últimas versiones de Node. 